### PR TITLE
Add visual cue for archived repositories.

### DIFF
--- a/components/org-repos/componentCss/repo.css
+++ b/components/org-repos/componentCss/repo.css
@@ -33,6 +33,14 @@ ol.repos .repo {
   margin-bottom: 10px;
 }
 
+ol.repos .repo[data-archived="true"] {
+  opacity: 0.5;
+}
+
+ol.repos .repo[data-archived="true"] h3:after {
+  content: " (archived)";
+}
+
 ol.repos .repo .members:not(.simply-empty) {
   background-color: white;
   padding: 10px;

--- a/components/org-repos/componentTemplates/org-repos.html
+++ b/components/org-repos/componentTemplates/org-repos.html
@@ -1,6 +1,10 @@
 <ol class="repos" data-simply-list="orgRepos">
   <template>
-    <li class="repo">
+    <li class="repo"
+        data-simply-field="archived"
+        data-simply-content="attributes"
+        data-simply-attributes="data-archived"
+	>
       <h3 data-simply-field="name"></h3>
       <div class="teams" data-simply-list="teams">
         <template>

--- a/components/org-repos/componentTemplates/org-repos.json
+++ b/components/org-repos/componentTemplates/org-repos.json
@@ -21,6 +21,11 @@
         {"login" : "user", "role_name": "admin"},
         {"login" : "user", "role_name": "admin"}
       ]
+    },
+    {
+      "archived" : true,
+      "name" : "Archived Repo",
+      "teams" : [{"team" : "foo"}, {"team" : "bar"}]
     }
   ]
 }

--- a/generated.html
+++ b/generated.html
@@ -79,6 +79,14 @@
         margin-bottom: 10px;
     }
 
+    ol.repos .repo[data-archived="true"] {
+      opacity: 0.5;
+    }
+
+    ol.repos .repo[data-archived="true"] h3:after {
+      content: "(archived)";
+    }
+
     ol.repos .repo .members:not(.simply-empty) {
         background-color: white;
         padding: 10px;
@@ -495,7 +503,11 @@
 <template id="org-repos">
     <ol class="repos" data-simply-list="orgRepos">
         <template>
-            <li class="repo">
+            <li class="repo"
+                data-simply-field="archived"
+                data-simply-content="attributes"
+                data-simply-attributes="data-archived"
+            >
                 <h3 data-simply-field="name"></h3>
                 <div class="teams" data-simply-list="teams">
                     <template>


### PR DESCRIPTION
This MR marks archived repos as `(archived)`.

I'm already merging this, as I need it live, MR created so it can be reviewed retroactively.
